### PR TITLE
terra: improved multiple outputs

### DIFF
--- a/pkgs/development/compilers/terra/default.nix
+++ b/pkgs/development/compilers/terra/default.nix
@@ -1,17 +1,14 @@
-{ stdenv, lua, fetchFromGitHub, fetchurl, which, llvmPackages, ncurses,
-  enableSharedLibraries ? true }:
+{ stdenv, fetchFromGitHub, fetchurl, which, llvmPackages, ncurses, lua }:
 
-let llvm     = llvmPackages.llvm;
-    toRemove = if enableSharedLibraries
-                 then "libterra.a"
-                 else "terra.so";
+let
+  luajitArchive = "LuaJIT-2.0.4.tar.gz";
+  luajitSrc = fetchurl {
+    url = "http://luajit.org/download/${luajitArchive}";
+    sha256 = "0zc0y7p6nx1c0pp4nhgbdgjljpfxsb5kgwp4ysz22l1p2bms83v2";
+  };
+in
 
-    luajitArchive = "LuaJIT-2.0.4.tar.gz";
-    luajitSrc     = fetchurl {
-      url = "http://luajit.org/download/${luajitArchive}";
-      sha256 = "0zc0y7p6nx1c0pp4nhgbdgjljpfxsb5kgwp4ysz22l1p2bms83v2";
-    };
-in stdenv.mkDerivation rec {
+stdenv.mkDerivation rec {
   name = "terra-git-${version}";
   version = "2016-06-09";
 
@@ -22,29 +19,34 @@ in stdenv.mkDerivation rec {
     sha256 = "1c2i9ih331304bh31c5gh94fx0qa49rsn70pvczvdfhi8pmcms6g";
   };
 
-  outputs = [ "dev" "out" "bin" ];
+  outputs = [ "dev" "out" "bin" "static" ];
 
-  patchPhase = ''
+  postPatch = ''
     substituteInPlace Makefile --replace \
       '-lcurses' '-lncurses'
   '';
 
-  configurePhase = ''
+  preBuild = ''
     mkdir -p build
     cp ${luajitSrc} build/${luajitArchive}
   '';
 
   installPhase = ''
-    mkdir -p $out $bin $dev
-    cp -r "release/"* $out
-    mv $out/lib $dev
-    mv $out/include $dev
-    mv $out/bin $bin
-    rm -f $dev/lib/${toRemove}
+    mkdir -pv $out/lib
+    cp -v release/lib/terra.so $out/lib
+
+    mkdir -pv $bin/bin
+    cp -v release/bin/terra $bin/bin
+
+    mkdir -pv $static/lib
+    cp -v release/lib/libterra.a $static/lib
+
+    mkdir -pv $dev/include
+    cp -rv release/include/terra $dev/include
   ''
   ;
 
-  buildInputs = [ which lua llvm llvmPackages.clang-unwrapped ncurses ];
+  buildInputs = with llvmPackages; [ which lua llvm clang-unwrapped ncurses ];
 
   meta = with stdenv.lib; {
     inherit (src.meta) homepage;

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -5348,8 +5348,7 @@ in
   tbb = callPackage ../development/libraries/tbb { };
 
   terra = callPackage ../development/compilers/terra {
-    llvm = llvmPackages_35.llvm.override { enableSharedLibraries = false; };
-    clang = clang_35;
+    llvmPackages = llvmPackages_38;
     lua = lua5_1;
   };
 


### PR DESCRIPTION
Hi, this is a proof of concept that seems to work as expected. Feel free to integrate this into your patch as you see fit.

This generates the following results
- out/lib/terra.so
- bin/bin/terra
- dev/include/terra/*.h
- static/lib/libterra.a

The static output obviates the need for `enableSharedLibraries.

Some inconsequential stylistic changes
- Remove the top-level `llvm` binding; inline into `buildInputs`
- Use `post/pre` phase hooks rather than overriding, except for `install` where
  we really do want to override the default phase entirely
